### PR TITLE
handle None value in field index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then get_python_environment $TERRYFY_PYTHON venv; fi
+    - pip install --upgrade pip
 install:
     - pip install -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,20 @@ matrix:
           python: pypy3
         - os: osx
           language: generic
-          env: TERRYFY_PYTHON='homebrew 2'
+          env: TERRYFY_PYTHON='macpython 2.7'
+        - os: osx
+          language: generic
+          env: TERRYFY_PYTHON='macpython 3.3'
         - os: osx
           language: generic
           env: TERRYFY_PYTHON='macpython 3.4'
-        - os: osx
+       - os: osx
           language: generic
-          env: TERRYFY_PYTHON='homebrew 3'
+          env: TERRYFY_PYTHON='macpython 3.5'
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then get_python_environment $TERRYFY_PYTHON venv; fi
-    - if [[ "$TERRYFY_PYTHON" == "homebrew 3" ]]; then alias pip=`which pip3` ; fi
 install:
     - pip install -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ matrix:
           env: TERRYFY_PYTHON='macpython 2.7'
         - os: osx
           language: generic
-          env: TERRYFY_PYTHON='macpython 3.3'
-        - os: osx
-          language: generic
           env: TERRYFY_PYTHON='macpython 3.4'
         - os: osx
           language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - os: osx
           language: generic
           env: TERRYFY_PYTHON='macpython 3.4'
-       - os: osx
+        - os: osx
           language: generic
           env: TERRYFY_PYTHON='macpython 3.5'
 before_install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.2.1 (unreleased)
 ------------------
 
-- TBD
+- None are now valid values in a field index. This requires BTrees >= 4.4.1
 
 4.2.0 (2016-06-10)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(name='zope.index',
         'tools': ['ZODB', 'transaction']},
       install_requires=[
         'persistent',
-        'BTrees',
+        'BTrees>=4.4.1',
         'setuptools',
         'six',
         'zope.interface'],

--- a/src/zope/index/field/index.py
+++ b/src/zope/index/field/index.py
@@ -21,6 +21,8 @@ from BTrees.Length import Length
 from zope.index import interfaces
 from zope.index.field.sorting import SortingIndexMixin
 
+_MARKER = object()
+
 @zope.interface.implementer(
         interfaces.IInjection,
         interfaces.IStatistics,
@@ -59,9 +61,12 @@ class FieldIndex(SortingIndexMixin, persistent.Persistent):
                 # no need to index the doc, its already up to date
                 return
             self.unindex_doc(docid)
-
         # Insert into forward index.
-        set = self._fwd_index.get(value)
+        try:
+            set = self._fwd_index.get(value)
+        except:
+            import pdb
+            pdb.set_trace()
         if set is None:
             set = self.family.IF.TreeSet()
             self._fwd_index[value] = set
@@ -76,9 +81,8 @@ class FieldIndex(SortingIndexMixin, persistent.Persistent):
     def unindex_doc(self, docid):
         """See interface IInjection"""
         rev_index = self._rev_index
-        if docid in rev_index:
-            value = rev_index[docid]
-        else:
+        value = rev_index.get(docid, _MARKER)
+        if value is _MARKER:
             return # not in index
 
         del rev_index[docid]

--- a/src/zope/index/field/index.py
+++ b/src/zope/index/field/index.py
@@ -62,11 +62,7 @@ class FieldIndex(SortingIndexMixin, persistent.Persistent):
                 return
             self.unindex_doc(docid)
         # Insert into forward index.
-        try:
-            set = self._fwd_index.get(value)
-        except:
-            import pdb
-            pdb.set_trace()
+        set = self._fwd_index.get(value)
         if set is None:
             set = self.family.IF.TreeSet()
             self._fwd_index[value] = set

--- a/src/zope/index/field/index.py
+++ b/src/zope/index/field/index.py
@@ -66,11 +66,12 @@ class FieldIndex(SortingIndexMixin, persistent.Persistent):
 
         try:
             # Insert into forward index.
-            set = self._fwd_index.get(value)
-            if set is None:
-                set = self.family.IF.TreeSet()
-                self._fwd_index[value] = set
-            set.insert(docid)
+            if value is not None:
+                set = self._fwd_index.get(value)
+                if set is None:
+                    set = self.family.IF.TreeSet()
+                    self._fwd_index[value] = set
+                set.insert(docid)
         except TypeError:
             # TypeError is caused by improper keys on the latest version of BTree
             pass

--- a/src/zope/index/field/tests.py
+++ b/src/zope/index/field/tests.py
@@ -320,10 +320,10 @@ class FieldIndexTests(unittest.TestCase):
         index.index_doc(1, 5)
         index.index_doc(1, None)
 
-    def test_insert_none_value_does_not_insert_into_forward_index(self):
+    def test_insert_none_value_does_insert_into_forward_index(self):
         index = self._makeOne()
         index.index_doc(1, None)
-        self.assertEquals(len(index._fwd_index), 0)
+        self.assertEquals(len(index._fwd_index), 1)
         self.assertEquals(len(index._rev_index), 1)
 
 def test_suite():


### PR DESCRIPTION
This should fix a test that depended upon None not being an acceptable key in Btree, which is no longer valid for current versions of BTree.