### PR TITLE
Make the C implementation of okascore importable under Python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ matrix:
         - os: linux
           python: 2.7
         - os: linux
+          python: 2.7
+          env: PURE_PYTHON=1
+        - os: linux
           python: 3.3
         - os: linux
           python: 3.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Changes
   because it was expected that these were usually ``None``.
 - Add support for Python 3.6. See `issue 8
   <https://github.com/zopefoundation/zope.index/issues/8>`_.
+- Make the C implementation of the text index's score function
+  (``zope.text.index.okascore``) importable under Python 3. Previously
+  we would fall back to a pure-Python implementation. See `issue 14
+  <https://github.com/zopefoundation/zope.index/issues/14>`_.
 
 4.2.0 (2016-06-10)
 ------------------

--- a/src/zope/index/text/okascore.c
+++ b/src/zope/index/text/okascore.c
@@ -35,6 +35,10 @@
 
 #include "Python.h"
 
+#if PY_MAJOR_VERSION >= 3
+#define PY3K
+#endif
+
 #define K1 1.2
 #define B  0.75
 
@@ -128,11 +132,32 @@ static PyMethodDef okascore_functions[] = {
 	{NULL}
 };
 
-void
-initokascore(void)
+#ifdef PY3K
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "okascore",                           /* m_name */
+        "inner scoring loop for Okapi rank",  /* m_doc */
+        -1,                                   /* m_size */
+        okascore_functions,                   /* m_methods */
+        NULL,                                 /* m_reload */
+        NULL,                                 /* m_traverse */
+        NULL,                                 /* m_clear */
+        NULL,                                 /* m_free */
+    };
+
+PyMODINIT_FUNC
+PyInit_okascore(void)
 {
 	PyObject *m;
-
-	m = Py_InitModule3("okascore", okascore_functions,
-			    "inner scoring loop for Okapi rank");
+    m = PyModule_Create(&moduledef);
+    return m;
 }
+#else
+PyMODINIT_FUNC
+initokascore(void)
+{
+	/* XXX: Error checking */
+	Py_InitModule3("okascore", okascore_functions,
+				   "inner scoring loop for Okapi rank");
+}
+#endif

--- a/src/zope/index/text/tests/test_okapiindex.py
+++ b/src/zope/index/text/tests/test_okapiindex.py
@@ -150,8 +150,14 @@ class OkapiIndexTest64(OkapiIndexTestBase, unittest.TestCase):
         import BTrees
         return BTrees.family64
 
+class TestScore(unittest.TestCase):
+
+    def test_score_extension(self):
+        from zope.index.text.okapiindex import PURE_PYTHON, score
+        if PURE_PYTHON:
+            self.assertIsNone(score)
+        else:
+            self.assertIsNotNone(score)
+
 def test_suite():
-    return unittest.TestSuite((
-                      unittest.makeSuite(OkapiIndexTest32),
-                      unittest.makeSuite(OkapiIndexTest64),
-                    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
Fixes #14

Add PURE_PYTHON support and testing for the score function.