### PR TITLE
python3.7 builds for linux, mac, and windows

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -8,7 +8,8 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp33"* ]] || \
        [[ "${PYBIN}" == *"cp34"* ]] || \
        [[ "${PYBIN}" == *"cp35"* ]] || \
-       [[ "${PYBIN}" == *"cp36"* ]]; then
+       [[ "${PYBIN}" == *"cp36"* ]] || \
+       [[ "${PYBIN}" == *"cp37"* ]]; then
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         rm -rf /io/build /io/*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
         - os: linux
           python: 3.6
         - os: linux
+          python: 3.7
+          dist: xenial
+          sudo: true
+        - os: linux
           python: pypy
         - os: linux
           python: pypy3
@@ -29,6 +33,9 @@ matrix:
         - os: osx
           language: generic
           env: TERRYFY_PYTHON='macpython 3.6.1'
+        - os: osx
+          language: generic
+          env: TERRYFY_PYTHON='macpython 3.7.0'
         - services:
             - docker
           env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 
 - Drop support for Python 3.3.
 
+- Add support for Python 3.7. ``SortingIndexMixin.sort`` now just
+  returns instead of raising ``StopIteration`` as required by
+  :pep:`479`. See `issue 20 <https://github.com/zopefoundation/zope.index/pull/20>`_.
+
 - Docs are now hosted at https://zopeindex.readthedocs.io/
 
 - Drop support for ``setup.py test``.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
     - python: 35-x64
     - python: 36
     - python: 36-x64
+    - python: 37
+    - python: 37-x64
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,11 @@ def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
 
-long_description = (open('README.rst').read() +
-                    '\n\n' +
-                    open('CHANGES.rst').read())
+long_description = (
+    read('README.rst')
+    + '\n\n'
+    + read('CHANGES.rst')
+)
 
 class optional_build_ext(build_ext):
     """This class subclasses build_ext and allows
@@ -85,6 +87,7 @@ setup(name='zope.index',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',

--- a/src/zope/index/field/sorting.py
+++ b/src/zope/index/field/sorting.py
@@ -36,13 +36,13 @@ class SortingIndexMixin(object):
 
         numdocs = getattr(self, self._sorting_num_docs_attr).value
         if not numdocs:
-            raise StopIteration
+            return
 
         if not isinstance(docids,
                           (self.family.IF.Set, self.family.IF.TreeSet)):
             docids = self.family.IF.Set(docids)
         if not docids:
-            raise StopIteration
+            return
 
         rlen = len(docids)
 
@@ -88,7 +88,7 @@ class SortingIndexMixin(object):
                 it = iter(iterable)
                 result = sorted(islice(it, 0, limit))
                 if not result:
-                    raise StopIteration
+                    return
                 insort = bisect.insort
                 pop = result.pop
                 los = result[-1]    # los --> Largest of the nsmallest
@@ -118,7 +118,7 @@ class SortingIndexMixin(object):
                         n += 1
                         yield docid
                         if limit and n >= limit:
-                            raise StopIteration
+                            return
             else:
                 # If the result set is not much larger than the number
                 # of documents in this index, or if we need to sort in
@@ -129,4 +129,4 @@ class SortingIndexMixin(object):
                         n += 1
                         yield docid
                         if limit and n >= limit:
-                            raise StopIteration
+                            return

--- a/src/zope/index/field/tests.py
+++ b/src/zope/index/field/tests.py
@@ -323,8 +323,8 @@ class FieldIndexTests(unittest.TestCase):
     def test_insert_none_value_does_insert_into_forward_index(self):
         index = self._makeOne()
         index.index_doc(1, None)
-        self.assertEquals(len(index._fwd_index), 1)
-        self.assertEquals(len(index._rev_index), 1)
+        self.assertEqual(len(index._fwd_index), 1)
+        self.assertEqual(len(index._rev_index), 1)
 
 def test_suite():
     return unittest.TestSuite((

--- a/src/zope/index/text/ricecode.py
+++ b/src/zope/index/text/ricecode.py
@@ -46,7 +46,10 @@ class BitArray(object):
         self.bitsleft = 0
 
     def tostring(self):
-        return self.bytes.tostring()
+        # tostring is deprecated on Python 3, but tobytes isn't available
+        # on Python 2
+        tobytes = getattr(self.bytes, 'tobytes', None) or self.bytes.tostring
+        return tobytes()
 
     def __getitem__(self, i):
         byte, offset = divmod(i, 8)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,pypy,pypy3,coverage,docs
+    py27,py34,py35,py36,py37,pypy,pypy3,coverage,docs
 
 [testenv]
 commands =


### PR DESCRIPTION
This PR directs appveyor and travis to build wheels for python 3.7