### PR TITLE
Drop Python 3.3 from .manylinux-install.sh

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -5,7 +5,6 @@ set -e -x
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \
-       [[ "${PYBIN}" == *"cp33"* ]] || \
        [[ "${PYBIN}" == *"cp34"* ]] || \
        [[ "${PYBIN}" == *"cp35"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]] || \


### PR DESCRIPTION
This was overlooked when dd38abc6bee3ac849623e4beaa528d7ce4a9422d
dropped Python 3.3 from the other files.