### PR TITLE
terrify now supports python 3.8 builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,10 @@ jobs:
       os: osx
       language: generic
       env: TERRYFY_PYTHON='macpython 3.7.0'
+    - name: Python 3.8 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.8.0'
 
 before_install:
   - |


### PR DESCRIPTION
terrify has been updated to support python 3.8 builds on travis.