### PR TITLE
Remove warning in python3.8

### DIFF
--- a/src/zope/index/text/okascore.c
+++ b/src/zope/index/text/okascore.c
@@ -101,7 +101,7 @@ score(PyObject *self, PyObject *args)
 			return NULL;
 		}
 #ifdef PY3K
-		lenweight = B_FROM1 + B * PyLong_AsLong(doclen) / meandoclen;
+		lenweight = B_FROM1 + B * PyFloat_AsDouble(doclen) / meandoclen;
 #else
 		lenweight = B_FROM1 + B * PyInt_AsLong(doclen) / meandoclen;
 #endif


### PR DESCRIPTION
I think we can just change this, can't think of any downside and our tests pass without warnings

Fixes #30